### PR TITLE
Another (s)cPCA example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: tenx-unfiltered-pbmc4k.md muraro-pancreas.md segerstolpe-pancreas.md zeisel-brain.md bach-mammary.md lun-416b.md grun-hsc.md tenx-filtered-pbmc3k-4k-8k.md lawlor-pancreas.md grun-pancreas.md tenx-repertoire-pbmc8k.md pijuan-embryo.md nestorowa-hsc.md about-the-contributors.md beyond-r-basics.md bibliography.md data-infrastructure.md hca-bone-marrow.md index.md interoperability.md introduction.md learning-r-and-bioconductor.md nuclei-analysis.md overview.md paul-hsc.md protein-abundance.md big-data.md droplet-processing.md interactive.md normalization.md reduced-dimensions.md cell-annotation.md doublet-detection.md clustering.md feature-selection.md quality-control.md cell-cycle.md data-integration.md marker-detection.md merged-pancreas.md repertoire-seq.md sample-comparisons.md trajectory.md
+all: tenx-unfiltered-pbmc4k.md muraro-pancreas.md segerstolpe-pancreas.md zeisel-brain.md bach-mammary.md lun-416b.md grun-hsc.md tenx-filtered-pbmc3k-4k-8k.md lawlor-pancreas.md grun-pancreas.md tenx-repertoire-pbmc8k.md pijuan-embryo.md nestorowa-hsc.md about-the-contributors.md beyond-r-basics.md bibliography.md data-infrastructure.md hca-bone-marrow.md index.md interoperability.md introduction.md learning-r-and-bioconductor.md messmer-hesc.md nuclei-analysis.md overview.md paul-hsc.md protein-abundance.md big-data.md droplet-processing.md interactive.md normalization.md reduced-dimensions.md cell-annotation.md doublet-detection.md clustering.md feature-selection.md quality-control.md cell-cycle.md data-integration.md marker-detection.md merged-pancreas.md repertoire-seq.md sample-comparisons.md trajectory.md
 
 tenx-unfiltered-pbmc4k.md: tenx-unfiltered-pbmc4k.Rmd
 	R -e "knitr::knit('tenx-unfiltered-pbmc4k.Rmd')"
@@ -65,6 +65,9 @@ introduction.md: introduction.Rmd
 
 learning-r-and-bioconductor.md: learning-r-and-bioconductor.Rmd
 	R -e "knitr::knit('learning-r-and-bioconductor.Rmd')"
+
+messmer-hesc.md: messmer-hesc.Rmd
+	R -e "knitr::knit('messmer-hesc.Rmd')"
 
 nuclei-analysis.md: nuclei-analysis.Rmd
 	R -e "knitr::knit('nuclei-analysis.Rmd')"

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -50,6 +50,7 @@ rmd_files: ["index.Rmd",
     "nestorowa-hsc.Rmd",
     "pijuan-embryo.Rmd",
     "bach-mammary.Rmd",
+    "messmer-hesc.Rmd",
     "hca-bone-marrow.Rmd",
     # Part 4, other crap:
     "about-the-contributors.Rmd",

--- a/about-the-contributors.Rmd
+++ b/about-the-contributors.Rmd
@@ -41,3 +41,5 @@ Kevin Rue-Albrecht (University of Oxford, United Kingdom), for contributing the 
 Charlotte Soneson (Friedrich Miescher Institute, Switzerland), for many formatting and typographical fixes.
 
 Al J Abadi (University of Melbourne, Australia), for bringing the log-normalization corner case to our attention.
+
+Philippe Boileau (University of California Berkeley, USA), for demonstrations on how to use scPCA. 

--- a/cell-cycle.Rmd
+++ b/cell-cycle.Rmd
@@ -437,6 +437,7 @@ stopifnot(median(con.sil$width) > 0.3)
 The strength of this approach lies in its ability to accurately remove the cell cycle effect based on its magnitude in the control dataset.
 This avoids loss of heterogeneity associated with other processes that happen to be correlated with the cell cycle.
 The requirements for the control dataset are also quite loose - there is no need to know the cell cycle phase of each cell _a priori_, and indeed, we can manufacture a like-for-like control by subsetting our dataset to a homogeneous cluster in which the only detectable factor of variation is the cell cycle.
+(See Chapter \@ref(messmer-hesc) for another demonstration of cPCA to remove the cell cycle effect.)
 In fact, any consistent but uninteresting variation can be eliminated in this manner as long as it is captured by the control.
 
 The downside is that the magnitude of variation in the control dataset must accurately reflect that in the test dataset, requiring more care in choosing the former.

--- a/messmer-hesc.Rmd
+++ b/messmer-hesc.Rmd
@@ -1,4 +1,9 @@
-# Messmer human ESC (Smart-seq2) {#messmer-hsc}
+# Messmer human ESC (Smart-seq2) {#messmer-hesc}
+
+```{r, echo=FALSE, results='asis'}
+library(rebook)
+chapterPreamble()
+```
 
 ## Introduction
 
@@ -26,13 +31,13 @@ rowData(sce.mess) <- anno[match(rownames(sce.mess), anno$GENEID),]
 ## Quality control
 
 ```{r qc-metrics, echo=FALSE}
-location <- rowRanges(sce)
+location <- rowRanges(sce.mess)
 is_mito <- any(seqnames(location) == "MT")
 
 library(scater)
 sce.mess <- addPerCellQC(sce.mess, subsets = list(Mito = is_mito))
 filtered <- quickPerCellQC(colData(sce.mess), sub.fields=TRUE, 
-    batch=sce$`experiment batch`) 
+    batch=sce.mess$`experiment batch`) 
 
 original <- sce.mess
 sce.mess <- sce.mess[,!filtered$discard]
@@ -95,7 +100,7 @@ sce.mess$phase <- assigned$phases
 ```
 
 ```{r}
-table(sce$phase)
+table(sce.mess$phase)
 ```
 
 ```{r unref-messmer-hesc-cyclone, fig.cap="G1 `cyclone()` phase scores against the G2/M phase scores for each cell in the Messmer hESC dataset."}
@@ -106,7 +111,7 @@ smoothScatter(assigned$scores$G1, assigned$scores$G2M, xlab="G1 score",
 ## Feature selection
 
 ```{r feature-selection}
-dec <- modelGeneVarWithSpikes(sce, "ERCC", block = sce$`experiment batch`)
+dec <- modelGeneVarWithSpikes(sce.mess, "ERCC", block = sce.mess$`experiment batch`)
 top.hvgs <- getTopHVGs(dec, prop = 0.1)
 ```
 
@@ -125,10 +130,11 @@ for (i in seq_along(dec$per.block)) {
 
 ## Batch correction 
 
-We eliminate the obvious batch effect between batches, which is possible due to the replicated nature of the experimental design.
+We eliminate the obvious batch effect between batches with linear regression, 
+which is possible due to the replicated nature of the experimental design.
 
-```{r batch-correction, echo=FALSE}
-# TODO: modify regressBatches to preserve some covariates.
+```{r batch-correction}
+# TODO: modify regressBatches to preserve some of the covariates.
 library(limma)
 assay(sce.mess, "corrected") <- removeBatchEffect(
   logcounts(sce.mess),
@@ -137,9 +143,7 @@ assay(sce.mess, "corrected") <- removeBatchEffect(
 )
 ```
 
-# Dimensionality Reduction
-
-## Across phenotypes 
+## Dimensionality Reduction
 
 ```{r dimensionality-reduction}
 set.seed(1101001)
@@ -159,199 +163,91 @@ gridExtra::grid.arrange(
 )
 ```
 
-Next, we perform contrastive PCA (cPCA) and sparse cPCA (scPCA) on the data to remove the cell cycle effect. 
-Given that the naive hESCs are actually reprogrammed primed hESCs, we will consider the primed hESCs as the "background" dataset.
-In this case, we use the phenotype in `clusters=` to help automatically determine a "good" value for the contrastive parameter, though simply setting `contrasts=` directly to a value such as 100 can often yield satisfactory results. 
-The 50 leading (sparse) contrastive PCs are then passed to t-SNE for visualization. 
+We perform contrastive PCA (cPCA) and sparse cPCA (scPCA) on the corrected log-expression data to obtain the same number of PCs.
+Given that the naive hESCs are actually reprogrammed primed hESCs, we will use the single batch of primed-only hESCs as the "background" dataset to remove the cell cycle effect.
 
 ```{r contrastive-pca}
 library(scPCA)
-target <- t(assay(sce.mess, "corrected")[top.hvgs, ])
-background <- target[sce.mess$phenotype == "primed",]
+is.bg <- sce.mess$`experiment batch`=="3"
+target <- sce.mess[,!is.bg]
+background <- sce.mess[,is.bg]
+
+mat.target <- t(assay(target, "corrected")[top.hvgs,])
+mat.background <- t(assay(background, "corrected")[top.hvgs,])
 
 set.seed(1010101001)
 con_out <- scPCA(
-    target = target,
-    background = background,
+    target = mat.target,
+    background = mat.background,
     penalties = 0, # no penalties, so cPCA.
     n_eigen = 50,
-    clusters = as.integer(as.factor(sce.mess$phenotype)),
-    contrasts = exp(seq(log(1), log(100), length.out = 5)),
+    clusters = as.integer(as.factor(target$phenotype)),
+    contrasts = 100,
     eigdecomp_iter=2000
 )
-reducedDim(sce.mess, "cPCA") <- con_out$x
-
-sparse_con_out <- scPCA(
-    target = target,
-    background = background,
-    clusters = as.integer(as.factor(sce.mess$phenotype)),
-    penalties = 1e-4, 
-    n_eigen = 50,
-    contrasts = con_out$contrast, 
-    alg = "rand_var_proj"
-)
-reducedDim(sce.mess, "scPCA") <- sparse_con_out$x
-
-set.seed(1101001)
-sce.mess <- runTSNE(sce.mess, dimred = "cPCA", perplexity = 40, name="cPCA+TSNE")
-sce.mess <- runTSNE(sce.mess, dimred = "scPCA", perplexity = 40, name="scPCA+TSNE")
+reducedDim(target, "cPCA") <- con_out$x
 ```
 
-Both cPCA and scPCA successfully remove the cell cycle effect from the naive hESCs and -- unsurprisingly -- the primed hESCs. 
-The cluster of primed hESCs is has an irregular shape in the cPCA embeddings, though this might be a side effect of including the background dataset in embedding. 
+```{r sparse-contrastive-pca}
+set.seed(101010101)
+sparse_con_out <- scPCA(
+    target = mat.target,
+    background = mat.background,
+    clusters = as.integer(as.factor(target$phenotype)),
+    penalties = 1e-4, 
+    n_eigen = 50,
+    contrasts = 100,
+    alg = "rand_var_proj"
+)
+reducedDim(target, "scPCA") <- sparse_con_out$x
+```
 
-```{r unref-messmer-hesc-cpca-tsne, fig.width=10, fig.height=6, fig.cap="More $t$-SNE plots of the Messmer hESC dataset after (sparse) contrastive PCA, where each point is a cell and is colored by various attributes."}
+We pass the top t0 PCs to t-SNE for visualization. 
+We see greater intermingling between phases within both the naive and primed cells after cPCA and scPCA.
+
+```{r tsne}
+set.seed(1101001)
+target <- runTSNE(target, dimred = "cPCA", perplexity = 40, name="cPCA+TSNE")
+target <- runTSNE(target, dimred = "scPCA", perplexity = 40, name="scPCA+TSNE")
+```
+
+```{r unref-messmer-hesc-cpca-tsne, fig.width=10, fig.height=4, fig.cap="More $t$-SNE plots of the Messmer hESC dataset after cPCA and scPCA, where each point is a cell and is colored by its assigned cell cycle phase."}
 gridExtra::grid.arrange(
-    plotReducedDim(sce.mess, "cPCA+TSNE", colour_by = "phase") + ggtitle("After cPCA"),
-    plotReducedDim(sce.mess, "scPCA+TSNE", colour_by = "phase") + ggtitle("After scPCA"),
+    plotReducedDim(target, "cPCA+TSNE", colour_by = "phase") + ggtitle("After cPCA"),
+    plotReducedDim(target, "scPCA+TSNE", colour_by = "phase") + ggtitle("After scPCA"),
     ncol=2
 )
 ```
 
+We can quantify the change in the separation between phases within each phenotype using the silhouette coefficient.
+
+```{r}
+library(bluster)
+naive <- target[,target$phenotype=="naive"]
+primed <- target[,target$phenotype=="primed"]
+
+N <- approxSilhouette(reducedDim(naive, "PCA"), naive$phase)
+P <- approxSilhouette(reducedDim(primed, "PCA"), primed$phase)
+c(naive=mean(N$width), primed=mean(P$width))
+
+cN <- approxSilhouette(reducedDim(naive, "cPCA"), naive$phase)
+cP <- approxSilhouette(reducedDim(primed, "cPCA"), primed$phase)
+c(naive=mean(cN$width), primed=mean(cP$width))
+
+scN <- approxSilhouette(reducedDim(naive, "scPCA"), naive$phase)
+scP <- approxSilhouette(reducedDim(primed, "scPCA"), primed$phase)
+c(naive=mean(scN$width), primed=mean(scP$width))
+```
+
 ```{r, echo=FALSE}
-# Sanity check for actual reduction in phase-related variance.
-original <- getVarianceExplained(t(reducedDim(sce.mess, "TSNE")), variables=colData(sce.mess)[,"phase",drop=FALSE])
-cpca <- getVarianceExplained(t(reducedDim(sce.mess, "cPCA+TSNE")), variables=colData(sce.mess)[,"phase",drop=FALSE])
-scpca <- getVarianceExplained(t(reducedDim(sce.mess, "scPCA+TSNE")), variables=colData(sce.mess)[,"phase",drop=FALSE])
-stopifnot(mean(original) > mean(cpca)*2)
-stopifnot(mean(original) > mean(scpca)*2)
+# Sanity check for reduction in the silhouette.
+original <- c(naive=mean(N$width), primed=mean(P$width))
+stopifnot(all(original > c(naive=mean(cN$width), primed=mean(cP$width))))
+stopifnot(all(original > c(naive=mean(scN$width), primed=mean(scP$width))))
 ```
 
-## Naive Human Embryonic Stem Cells
+## Session information
 
-Next, we perform cPCA and scPCA on the naive hESCs using the primed hESCs as
-a background dataset, and feed their ten leading components into t-SNE. This
-procedure is a more accurate representation of the workflow one might employ
-when applying contrastive dimension reduction methods since the target and
-background datasets are fully distinct.
-
-As in the previous section, one of the main sources of variation captured by the
-t-SNE embedding using the ten leading PCs as an initialization is cell
-cycle. Once again, this effect is removed by cPCA and scPCA. It's doubtful that
-this analysis will lead to any new insights, but it does demonstrate these
-methods works as expected.
-
-```{r naive-cells, fig.width=10, fig.height=10}
-set.seed(1433412)
-
-# define naive cells as target, background as primed
-target <- t(assay(sce, "corrected")[top_hvgs, sce$phenotype == "naive"])
-background <- t(assay(sce, "corrected")[top_hvgs, sce$phenotype == "primed"])
-sce_naive <- sce[, sce$phenotype == "naive"]
-
-# identify naive hESCs marker genes
-sce_naive$KLF4 <- assay(sce_naive, "corrected")[
-  which(rownames(sce_naive) == "ENSG00000136826"), ]
-sce_naive$KLF17 <- assay(sce_naive, "corrected")[
-  which(rownames(sce_naive) == "ENSG00000171872"), ] # not in top_hvgs
-sce_naive$DPPA3 <- assay(sce_naive, "corrected")[
-  which(rownames(sce_naive) == "ENSG00000187569"), ]
-sce_naive$TFCP2L1 <- assay(sce_naive, "corrected")[
-  which(rownames(sce_naive) == "ENSG00000115112"), ]
-sce_naive$NANOG <- assay(sce_naive, "corrected")[
-  which(rownames(sce_naive) == "ENSG00000111704"), ] # not in top_hvgs
-
-# identify linage markers
-sce_naive$SNAI1 <- assay(sce_naive, "corrected")[
-  which(rownames(sce_naive) == "ENSG00000124216"), ] # not in top_hvgs
-sce_naive$ITGA6 <- assay(sce_naive, "corrected")[
-  which(rownames(sce_naive) == "ENSG00000091409"), ] # not in top_hvgs
-sce_naive$PAF1 <- assay(sce_naive, "corrected")[
-  which(rownames(sce_naive) == "ENSG00000006712"), ] # not in top_hvgs
-
-
-# perform PCA
-sce_naive <- runPCA(sce_naive, subset_row = top_hvgs,
-                    exprs_values = "corrected")
-sce_naive <- runTSNE(sce_naive, dimred = "PCA")
-naive_PCA_CDK1_p <- plotTSNE(sce_naive, colour_by = "CDK1")
-naive_PCA_phase_p <- plotTSNE(sce_naive, colour_by = "phase")
-
-# perform cPCA
-con_naive_out <- scPCA(
-  target = target,
-  background = background,
-  n_centers = 2,
-  penalties = 0, contrasts = 20, # fixed -- based on result of con_out
-  n_eigen = 10
-)
-reducedDim(sce_naive, "cPCA") <- con_naive_out$x
-sce_naive <- runTSNE(sce_naive, dimred = "cPCA")
-naive_cPCA_CDK1_p <- plotTSNE(sce_naive, colour_by = "CDK1")
-naive_cPCA_phase_p <- plotTSNE(sce_naive, colour_by = "phase")
-naive_cPCA_KLF4_p <- plotTSNE(sce_naive, colour_by = "KLF4")
-naive_cPCA_KLF17_p <- plotTSNE(sce_naive, colour_by = "KLF17")
-naive_cPCA_DPPA3_p <- plotTSNE(sce_naive, colour_by = "DPPA3")
-naive_cPCA_TFCP2L1_p <- plotTSNE(sce_naive, colour_by = "TFCP2L1")
-naive_cPCA_NANOG_p <- plotTSNE(sce_naive, colour_by = "NANOG")
-naive_cPCA_SNAI1_p <- plotTSNE(sce_naive, colour_by = "SNAI1")
-naive_cPCA_ITGA6_p <- plotTSNE(sce_naive, colour_by = "ITGA6")
-naive_cPCA_PAF1_p <- plotTSNE(sce_naive, colour_by = "PAF1")
-
-
-# perform scPCA
-sparse_con_naive_out <- scPCA(
-  target = target,
-  background = background,
-  n_centers = 2,
-  penalties = 1e-5, contrasts = 20, # fixed -- based on result of con_out
-  n_eigen = 10,
-  alg = "rand_var_proj"
-)
-reducedDim(sce_naive, "scPCA") <- sparse_con_naive_out$x
-sce_naive <- runTSNE(sce_naive, dimred = "scPCA")
-naive_scPCA_CDK1_p <- plotTSNE(sce_naive, colour_by = "CDK1")
-naive_scPCA_phase_p <- plotTSNE(sce_naive, colour_by = "phase")
-naive_scPCA_KLF4_p <- plotTSNE(sce_naive, colour_by = "KLF4")
-naive_scPCA_KLF17_p <- plotTSNE(sce_naive, colour_by = "KLF17")
-naive_scPCA_DPPA3_p <- plotTSNE(sce_naive, colour_by = "DPPA3")
-naive_scPCA_TFCP2L1_p <- plotTSNE(sce_naive, colour_by = "TFCP2L1")
-naive_scPCA_NANOG_p <- plotTSNE(sce_naive, colour_by = "NANOG")
-naive_scPCA_SNAI1_p <- plotTSNE(sce_naive, colour_by = "SNAI1")
-naive_scPCA_ITGA6_p <- plotTSNE(sce_naive, colour_by = "ITGA6")
-naive_scPCA_PAF1_p <- plotTSNE(sce_naive, colour_by = "PAF1")
-
-# plot the results
-gridExtra::grid.arrange(
-  naive_PCA_CDK1_p + ggtitle("PCA: CDK1 Expression, Naive hESCs"),
-  naive_PCA_phase_p + ggtitle("PCA: Cell Cycle Phase, Naive hESCs"),
-  naive_cPCA_CDK1_p + ggtitle("cPCA"),
-  naive_cPCA_phase_p + ggtitle("cPCA"),
-  naive_scPCA_CDK1_p + ggtitle("scPCA"),
-  naive_scPCA_phase_p + ggtitle("cPCA"),
-  ncol = 2
-)
-```
-
-We also verify that the gene expression of germ layer-specific marker genes do
-not possess any lineage-associated structure, as in Figure 3a of Messmer et al.
-Similarly, we plot the selected naive hESCs marker genes from Figure 2b, and
-determine that no spurious pattern emerges.
-
-```{r marker-genes, fig.width=10, fig.height=15}
-gridExtra::grid.arrange(
-  naive_cPCA_KLF4_p + ggtitle("cPCA"),
-  naive_scPCA_KLF4_p + ggtitle("scPCA"),
-  naive_cPCA_KLF17_p + ggtitle("cPCA"),
-  naive_scPCA_KLF17_p + ggtitle("scPCA"),
-  naive_cPCA_DPPA3_p + ggtitle("cPCA"),
-  naive_scPCA_DPPA3_p + ggtitle("scPCA"),
-  naive_cPCA_TFCP2L1_p + ggtitle("cPCA"),
-  naive_scPCA_TFCP2L1_p + ggtitle("scPCA"),
-  naive_cPCA_NANOG_p + ggtitle("cPCA"),
-  naive_scPCA_NANOG_p + ggtitle("scPCA"),
-  ncol = 2
-)
-```
-
-```{r lineage-markers, fig.width=10, fig.height=10}
-gridExtra::grid.arrange(
-  naive_cPCA_SNAI1_p + ggtitle("cPCA"),
-  naive_scPCA_SNAI1_p + ggtitle("scPCA"),
-  naive_cPCA_ITGA6_p + ggtitle("cPCA"),
-  naive_scPCA_ITGA6_p + ggtitle("scPCA"),
-  naive_cPCA_PAF1_p + ggtitle("cPCA"),
-  naive_scPCA_PAF1_p + ggtitle("scPCA"),
-  ncol = 2
-)
+```{r, echo=FALSE, results='asis'}
+prettySessionInfo()
 ```

--- a/messmer-hesc.Rmd
+++ b/messmer-hesc.Rmd
@@ -179,11 +179,9 @@ set.seed(1010101001)
 con_out <- scPCA(
     target = mat.target,
     background = mat.background,
-    penalties = 0, # no penalties, so cPCA.
+    penalties = 0, # no penalties = non-sparse cPCA.
     n_eigen = 50,
-    clusters = as.integer(as.factor(target$phenotype)),
-    contrasts = 100,
-    eigdecomp_iter=2000
+    contrasts = 100
 )
 reducedDim(target, "cPCA") <- con_out$x
 ```
@@ -193,16 +191,14 @@ set.seed(101010101)
 sparse_con_out <- scPCA(
     target = mat.target,
     background = mat.background,
-    clusters = as.integer(as.factor(target$phenotype)),
-    penalties = 1e-4, 
+    penalties = 1e-4,
     n_eigen = 50,
     contrasts = 100,
-    alg = "rand_var_proj"
+    alg = "rand_var_proj" # for speed.
 )
 reducedDim(target, "scPCA") <- sparse_con_out$x
 ```
 
-We pass the top t0 PCs to t-SNE for visualization. 
 We see greater intermingling between phases within both the naive and primed cells after cPCA and scPCA.
 
 ```{r tsne}

--- a/messmer-hesc.Rmd
+++ b/messmer-hesc.Rmd
@@ -1,0 +1,357 @@
+# Messmer human ESC (Smart-seq2) {#messmer-hsc}
+
+## Introduction
+
+This performs an analysis of the human embryonic stem cell (hESC) dataset generated with Smart-seq2 [@messmer2019transcriptional], which contains several plates of naive and primed hESCs.
+The chapter's code is based on the steps in the paper's [GitHub repository](https://github.com/MarioniLab/NaiveHESC2016/blob/master/analysis/preprocess.Rmd), with some additional steps for cell cycle effect removal contributed by Philippe Boileau.
+
+## Data loading
+
+Converting the batch to a factor, to make life easier later on.
+
+```{r load-data, echo=FALSE}
+library(scRNAseq)
+sce.mess <- MessmerESCData()
+sce.mess$`experiment batch` <- factor(sce.mess$`experiment batch`)
+```
+
+```{r gene-annotations}
+library(AnnotationHub)
+ens.hs.v97 <- AnnotationHub()[["AH73881"]]
+anno <- select(ens.hs.v97, keys=rownames(sce.mess), 
+    keytype="GENEID", columns=c("SYMBOL"))
+rowData(sce.mess) <- anno[match(rownames(sce.mess), anno$GENEID),]
+```
+
+## Quality control
+
+```{r qc-metrics, echo=FALSE}
+location <- rowRanges(sce)
+is_mito <- any(seqnames(location) == "MT")
+
+library(scater)
+sce.mess <- addPerCellQC(sce.mess, subsets = list(Mito = is_mito))
+filtered <- quickPerCellQC(colData(sce.mess), sub.fields=TRUE, 
+    batch=sce$`experiment batch`) 
+
+original <- sce.mess
+sce.mess <- sce.mess[,!filtered$discard]
+```
+
+Let's have a look at the QC statistics.
+
+```{r}
+colSums(as.matrix(filtered))
+```
+
+```{r unref-messmer-hesc-qc, fig.width=6, fig.height=10, fig.cap="Distribution of QC metrics across batches (x-axis) and phenotypes (facets) for cells in the Messmer hESC dataset. Each point is a cell and is colored by whether it was discarded."}
+gridExtra::grid.arrange(
+    plotColData(original, x="experiment batch", y="sum",
+        colour_by=I(filtered$discard), other_field="phenotype") +
+        facet_wrap(~phenotype) + scale_y_log10(),
+    plotColData(original, x="experiment batch", y="detected",
+        colour_by=I(filtered$discard), other_field="phenotype") +
+        facet_wrap(~phenotype) + scale_y_log10(),
+    plotColData(original, x="experiment batch", y="subsets_Mito_percent",
+        colour_by=I(filtered$discard), other_field="phenotype") +
+        facet_wrap(~phenotype),
+    plotColData(original, x="experiment batch", y="altexps_ERCC_percent",
+        colour_by=I(filtered$discard), other_field="phenotype") +
+        facet_wrap(~phenotype),
+    ncol=1
+)
+```
+
+## Normalization
+
+```{r normalization}
+library(scran)
+
+set.seed(10000)
+clusters <- quickCluster(sce.mess)
+sce.mess <- computeSumFactors(sce.mess, cluster=clusters)
+sce.mess <- logNormCounts(sce.mess)
+```
+
+```{r unref-messmer-hesc-norm, fig.cap="Deconvolution size factors plotted against the library size (left) and spike-in size factors plotted against the deconvolution size factors (right). Each point is a cell and is colored by its phenotype."}
+par(mfrow=c(1,2))
+plot(sce.mess$sum, sizeFactors(sce.mess), log = "xy", pch=16,
+     xlab = "Library size (millions)", ylab = "Size factor",
+     col = ifelse(sce.mess$phenotype == "naive", "black", "grey"))
+
+spike.sf <- librarySizeFactors(altExp(sce.mess, "ERCC"))
+plot(sizeFactors(sce.mess), spike.sf, log = "xy", pch=16,
+     ylab = "Spike-in size factor", xlab = "Deconvolution size factor",
+     col = ifelse(sce.mess$phenotype == "naive", "black", "grey"))
+```
+
+## Cell cycle phase assignment
+
+```{r cell-cycle}
+set.seed(10001)
+hs_pairs <- readRDS(system.file("exdata", "human_cycle_markers.rds", package="scran"))
+assigned <- cyclone(sce.mess, pairs=hs_pairs, gene.names=rownames(sce.mess))
+sce.mess$phase <- assigned$phases
+```
+
+```{r}
+table(sce$phase)
+```
+
+```{r unref-messmer-hesc-cyclone, fig.cap="G1 `cyclone()` phase scores against the G2/M phase scores for each cell in the Messmer hESC dataset."}
+smoothScatter(assigned$scores$G1, assigned$scores$G2M, xlab="G1 score",
+     ylab="G2/M score", pch=16)
+```
+
+## Feature selection
+
+```{r feature-selection}
+dec <- modelGeneVarWithSpikes(sce, "ERCC", block = sce$`experiment batch`)
+top.hvgs <- getTopHVGs(dec, prop = 0.1)
+```
+
+```{r unref-messmer-hesc-var, fig.width=12, fig.height=5, fig.cap="Per-gene variance of the log-normalized expression values in the Messmer hESC dataset, plotted against the mean for each batch. Each point represents a gene with spike-ins shown in red and the fitted trend shown in blue."}
+par(mfrow=c(1,3))
+for (i in seq_along(dec$per.block)) {
+    current <- dec$per.block[[i]]
+    plot(current$mean, current$total, xlab="Mean log-expression", 
+        ylab="Variance", pch=16, cex=0.5, main=paste("Batch", i))
+
+    fit <- metadata(current)
+    points(fit$mean, fit$var, col="red", pch=16)
+    curve(fit$trend(x), col='dodgerblue', add=TRUE, lwd=2)
+}
+```
+
+## Batch correction 
+
+We eliminate the obvious batch effect between batches, which is possible due to the replicated nature of the experimental design.
+
+```{r batch-correction, echo=FALSE}
+# TODO: modify regressBatches to preserve some covariates.
+library(limma)
+assay(sce.mess, "corrected") <- removeBatchEffect(
+  logcounts(sce.mess),
+  design = model.matrix(~sce.mess$phenotype),
+  batch = sce.mess$`experiment batch`
+)
+```
+
+# Dimensionality Reduction
+
+## Across phenotypes 
+
+```{r dimensionality-reduction}
+set.seed(1101001)
+sce.mess <- runPCA(sce.mess, subset_row = top.hvgs, exprs_values = "corrected")
+sce.mess <- runTSNE(sce.mess, dimred = "PCA", perplexity = 40)
+```
+
+From a naive PCA, the cell cycle appears to be a major source of biological variation within each phenotype.
+
+```{r unref-messmer-hesc-tsne, fig.width=10, fig.height=10, fig.cap="Obligatory $t$-SNE plots of the Messmer hESC dataset, where each point is a cell and is colored by various attributes."}
+gridExtra::grid.arrange(
+    plotTSNE(sce.mess, colour_by = "phenotype") + ggtitle("By phenotype"),
+    plotTSNE(sce.mess, colour_by = "experiment batch") + ggtitle("By batch "),
+    plotTSNE(sce.mess, colour_by = "CDK1", swap_rownames="SYMBOL") + ggtitle("By CDK1"),
+    plotTSNE(sce.mess, colour_by = "phase") + ggtitle("By phase"),
+    ncol = 2
+)
+```
+
+Next, we perform contrastive PCA (cPCA) and sparse cPCA (scPCA) on the data to remove the cell cycle effect. 
+Given that the naive hESCs are actually reprogrammed primed hESCs, we will consider the primed hESCs as the "background" dataset.
+In this case, we use the phenotype in `clusters=` to help automatically determine a "good" value for the contrastive parameter, though simply setting `contrasts=` directly to a value such as 100 can often yield satisfactory results. 
+The 50 leading (sparse) contrastive PCs are then passed to t-SNE for visualization. 
+
+```{r contrastive-pca}
+library(scPCA)
+target <- t(assay(sce.mess, "corrected")[top.hvgs, ])
+background <- target[sce.mess$phenotype == "primed",]
+
+set.seed(1010101001)
+con_out <- scPCA(
+    target = target,
+    background = background,
+    penalties = 0, # no penalties, so cPCA.
+    n_eigen = 50,
+    clusters = as.integer(as.factor(sce.mess$phenotype)),
+    contrasts = exp(seq(log(1), log(100), length.out = 5)),
+    eigdecomp_iter=2000
+)
+reducedDim(sce.mess, "cPCA") <- con_out$x
+
+sparse_con_out <- scPCA(
+    target = target,
+    background = background,
+    clusters = as.integer(as.factor(sce.mess$phenotype)),
+    penalties = 1e-4, 
+    n_eigen = 50,
+    contrasts = con_out$contrast, 
+    alg = "rand_var_proj"
+)
+reducedDim(sce.mess, "scPCA") <- sparse_con_out$x
+
+set.seed(1101001)
+sce.mess <- runTSNE(sce.mess, dimred = "cPCA", perplexity = 40, name="cPCA+TSNE")
+sce.mess <- runTSNE(sce.mess, dimred = "scPCA", perplexity = 40, name="scPCA+TSNE")
+```
+
+Both cPCA and scPCA successfully remove the cell cycle effect from the naive hESCs and -- unsurprisingly -- the primed hESCs. 
+The cluster of primed hESCs is has an irregular shape in the cPCA embeddings, though this might be a side effect of including the background dataset in embedding. 
+
+```{r unref-messmer-hesc-cpca-tsne, fig.width=10, fig.height=6, fig.cap="More $t$-SNE plots of the Messmer hESC dataset after (sparse) contrastive PCA, where each point is a cell and is colored by various attributes."}
+gridExtra::grid.arrange(
+    plotReducedDim(sce.mess, "cPCA+TSNE", colour_by = "phase") + ggtitle("After cPCA"),
+    plotReducedDim(sce.mess, "scPCA+TSNE", colour_by = "phase") + ggtitle("After scPCA"),
+    ncol=2
+)
+```
+
+```{r, echo=FALSE}
+# Sanity check for actual reduction in phase-related variance.
+original <- getVarianceExplained(t(reducedDim(sce.mess, "TSNE")), variables=colData(sce.mess)[,"phase",drop=FALSE])
+cpca <- getVarianceExplained(t(reducedDim(sce.mess, "cPCA+TSNE")), variables=colData(sce.mess)[,"phase",drop=FALSE])
+scpca <- getVarianceExplained(t(reducedDim(sce.mess, "scPCA+TSNE")), variables=colData(sce.mess)[,"phase",drop=FALSE])
+stopifnot(mean(original) > mean(cpca)*2)
+stopifnot(mean(original) > mean(scpca)*2)
+```
+
+## Naive Human Embryonic Stem Cells
+
+Next, we perform cPCA and scPCA on the naive hESCs using the primed hESCs as
+a background dataset, and feed their ten leading components into t-SNE. This
+procedure is a more accurate representation of the workflow one might employ
+when applying contrastive dimension reduction methods since the target and
+background datasets are fully distinct.
+
+As in the previous section, one of the main sources of variation captured by the
+t-SNE embedding using the ten leading PCs as an initialization is cell
+cycle. Once again, this effect is removed by cPCA and scPCA. It's doubtful that
+this analysis will lead to any new insights, but it does demonstrate these
+methods works as expected.
+
+```{r naive-cells, fig.width=10, fig.height=10}
+set.seed(1433412)
+
+# define naive cells as target, background as primed
+target <- t(assay(sce, "corrected")[top_hvgs, sce$phenotype == "naive"])
+background <- t(assay(sce, "corrected")[top_hvgs, sce$phenotype == "primed"])
+sce_naive <- sce[, sce$phenotype == "naive"]
+
+# identify naive hESCs marker genes
+sce_naive$KLF4 <- assay(sce_naive, "corrected")[
+  which(rownames(sce_naive) == "ENSG00000136826"), ]
+sce_naive$KLF17 <- assay(sce_naive, "corrected")[
+  which(rownames(sce_naive) == "ENSG00000171872"), ] # not in top_hvgs
+sce_naive$DPPA3 <- assay(sce_naive, "corrected")[
+  which(rownames(sce_naive) == "ENSG00000187569"), ]
+sce_naive$TFCP2L1 <- assay(sce_naive, "corrected")[
+  which(rownames(sce_naive) == "ENSG00000115112"), ]
+sce_naive$NANOG <- assay(sce_naive, "corrected")[
+  which(rownames(sce_naive) == "ENSG00000111704"), ] # not in top_hvgs
+
+# identify linage markers
+sce_naive$SNAI1 <- assay(sce_naive, "corrected")[
+  which(rownames(sce_naive) == "ENSG00000124216"), ] # not in top_hvgs
+sce_naive$ITGA6 <- assay(sce_naive, "corrected")[
+  which(rownames(sce_naive) == "ENSG00000091409"), ] # not in top_hvgs
+sce_naive$PAF1 <- assay(sce_naive, "corrected")[
+  which(rownames(sce_naive) == "ENSG00000006712"), ] # not in top_hvgs
+
+
+# perform PCA
+sce_naive <- runPCA(sce_naive, subset_row = top_hvgs,
+                    exprs_values = "corrected")
+sce_naive <- runTSNE(sce_naive, dimred = "PCA")
+naive_PCA_CDK1_p <- plotTSNE(sce_naive, colour_by = "CDK1")
+naive_PCA_phase_p <- plotTSNE(sce_naive, colour_by = "phase")
+
+# perform cPCA
+con_naive_out <- scPCA(
+  target = target,
+  background = background,
+  n_centers = 2,
+  penalties = 0, contrasts = 20, # fixed -- based on result of con_out
+  n_eigen = 10
+)
+reducedDim(sce_naive, "cPCA") <- con_naive_out$x
+sce_naive <- runTSNE(sce_naive, dimred = "cPCA")
+naive_cPCA_CDK1_p <- plotTSNE(sce_naive, colour_by = "CDK1")
+naive_cPCA_phase_p <- plotTSNE(sce_naive, colour_by = "phase")
+naive_cPCA_KLF4_p <- plotTSNE(sce_naive, colour_by = "KLF4")
+naive_cPCA_KLF17_p <- plotTSNE(sce_naive, colour_by = "KLF17")
+naive_cPCA_DPPA3_p <- plotTSNE(sce_naive, colour_by = "DPPA3")
+naive_cPCA_TFCP2L1_p <- plotTSNE(sce_naive, colour_by = "TFCP2L1")
+naive_cPCA_NANOG_p <- plotTSNE(sce_naive, colour_by = "NANOG")
+naive_cPCA_SNAI1_p <- plotTSNE(sce_naive, colour_by = "SNAI1")
+naive_cPCA_ITGA6_p <- plotTSNE(sce_naive, colour_by = "ITGA6")
+naive_cPCA_PAF1_p <- plotTSNE(sce_naive, colour_by = "PAF1")
+
+
+# perform scPCA
+sparse_con_naive_out <- scPCA(
+  target = target,
+  background = background,
+  n_centers = 2,
+  penalties = 1e-5, contrasts = 20, # fixed -- based on result of con_out
+  n_eigen = 10,
+  alg = "rand_var_proj"
+)
+reducedDim(sce_naive, "scPCA") <- sparse_con_naive_out$x
+sce_naive <- runTSNE(sce_naive, dimred = "scPCA")
+naive_scPCA_CDK1_p <- plotTSNE(sce_naive, colour_by = "CDK1")
+naive_scPCA_phase_p <- plotTSNE(sce_naive, colour_by = "phase")
+naive_scPCA_KLF4_p <- plotTSNE(sce_naive, colour_by = "KLF4")
+naive_scPCA_KLF17_p <- plotTSNE(sce_naive, colour_by = "KLF17")
+naive_scPCA_DPPA3_p <- plotTSNE(sce_naive, colour_by = "DPPA3")
+naive_scPCA_TFCP2L1_p <- plotTSNE(sce_naive, colour_by = "TFCP2L1")
+naive_scPCA_NANOG_p <- plotTSNE(sce_naive, colour_by = "NANOG")
+naive_scPCA_SNAI1_p <- plotTSNE(sce_naive, colour_by = "SNAI1")
+naive_scPCA_ITGA6_p <- plotTSNE(sce_naive, colour_by = "ITGA6")
+naive_scPCA_PAF1_p <- plotTSNE(sce_naive, colour_by = "PAF1")
+
+# plot the results
+gridExtra::grid.arrange(
+  naive_PCA_CDK1_p + ggtitle("PCA: CDK1 Expression, Naive hESCs"),
+  naive_PCA_phase_p + ggtitle("PCA: Cell Cycle Phase, Naive hESCs"),
+  naive_cPCA_CDK1_p + ggtitle("cPCA"),
+  naive_cPCA_phase_p + ggtitle("cPCA"),
+  naive_scPCA_CDK1_p + ggtitle("scPCA"),
+  naive_scPCA_phase_p + ggtitle("cPCA"),
+  ncol = 2
+)
+```
+
+We also verify that the gene expression of germ layer-specific marker genes do
+not possess any lineage-associated structure, as in Figure 3a of Messmer et al.
+Similarly, we plot the selected naive hESCs marker genes from Figure 2b, and
+determine that no spurious pattern emerges.
+
+```{r marker-genes, fig.width=10, fig.height=15}
+gridExtra::grid.arrange(
+  naive_cPCA_KLF4_p + ggtitle("cPCA"),
+  naive_scPCA_KLF4_p + ggtitle("scPCA"),
+  naive_cPCA_KLF17_p + ggtitle("cPCA"),
+  naive_scPCA_KLF17_p + ggtitle("scPCA"),
+  naive_cPCA_DPPA3_p + ggtitle("cPCA"),
+  naive_scPCA_DPPA3_p + ggtitle("scPCA"),
+  naive_cPCA_TFCP2L1_p + ggtitle("cPCA"),
+  naive_scPCA_TFCP2L1_p + ggtitle("scPCA"),
+  naive_cPCA_NANOG_p + ggtitle("cPCA"),
+  naive_scPCA_NANOG_p + ggtitle("scPCA"),
+  ncol = 2
+)
+```
+
+```{r lineage-markers, fig.width=10, fig.height=10}
+gridExtra::grid.arrange(
+  naive_cPCA_SNAI1_p + ggtitle("cPCA"),
+  naive_scPCA_SNAI1_p + ggtitle("scPCA"),
+  naive_cPCA_ITGA6_p + ggtitle("cPCA"),
+  naive_scPCA_ITGA6_p + ggtitle("scPCA"),
+  naive_cPCA_PAF1_p + ggtitle("cPCA"),
+  naive_scPCA_PAF1_p + ggtitle("scPCA"),
+  ncol = 2
+)
+```


### PR DESCRIPTION
This differs from  @PhilBoileau's provided Rmarkdown in a few ways:

- I streamlined the entire scPCA discussion by starting off with one of the primed-only batches as the background, which provides an independent dataset compared to all of the other naive/primed cells. This also gets rid of the wacky intestinal worm from the cPCA t-SNE.
- I ended up switching to an arbitrary hard-coded `contrasts=` due to the above, it seemed to yield a more aggressive removal of the background than relying on the auto-generated `clusters=`. I suspect this is because the `clusters=` will also penalizes any removal of the separation between phenotype, which I don't really care about because they're so well-separated anyway.
- Some other reasons for using `contrasts=` were more practical: it was faster and I didn't want to have to explain to the reader that the general method was still applicable even if you didn't have _a priori_ phenotype information.
- Setting `contrasts=` to a single value still complains about the need for a non-`NULL` `n_centers`.
- `scPCA()` should handle the coercion of `clusters=` to an integer internally, as a quality-of-life thing for users.